### PR TITLE
feat: add equipment filters and poc status metrics

### DIFF
--- a/app/actions/actions_projetos.ts
+++ b/app/actions/actions_projetos.ts
@@ -120,6 +120,33 @@ export async function getProjetoCount() {
   return count;
 }
 
+export async function getProjetoStatusCount() {
+  const supabase = createClient();
+
+  const [emAndamento, finalizadas] = await Promise.all([
+    supabase
+      .from("projetos")
+      .select("*", { count: "exact", head: true })
+      .eq("status", "Em Andamento"),
+    supabase
+      .from("projetos")
+      .select("*", { count: "exact", head: true })
+      .eq("status", "Finalizada"),
+  ]);
+
+  if (emAndamento.error) {
+    console.error("Erro ao buscar Projetos:", emAndamento.error);
+  }
+  if (finalizadas.error) {
+    console.error("Erro ao buscar Projetos:", finalizadas.error);
+  }
+
+  return {
+    emAndamento: emAndamento.count ?? 0,
+    finalizadas: finalizadas.count ?? 0,
+  };
+}
+
 export async function getProjetoByStatus() {
   const supabase = createClient();
   const { data } = await supabase

--- a/app/equipamentos/data-table.tsx
+++ b/app/equipamentos/data-table.tsx
@@ -63,6 +63,42 @@ export function DataTable({ data, pocMap, urlMap }) {
     pageIndex: 0,
     pageSize: 50,
   });
+  const [filterKey, setFilterKey] = React.useState(0);
+
+  const modeloOptions = React.useMemo(
+    () => Array.from(new Set(data.map((item) => item.model).filter(Boolean))),
+    [data]
+  );
+  const tipoOptions = React.useMemo(
+    () => Array.from(new Set(data.map((item) => item.type).filter(Boolean))),
+    [data]
+  );
+  const projetoOptions = React.useMemo(
+    () =>
+      Array.from(
+        new Set(
+          data
+            .map((item) => item.projeto_id?.projeto)
+            .filter((item) => item && item !== "")
+        )
+      ),
+    [data]
+  );
+  const empresaOptions = React.useMemo(
+    () =>
+      Array.from(
+        new Set(
+          data
+            .map((item) => item.projeto_id?.empresa)
+            .filter((item) => item && item !== "")
+        )
+      ),
+    [data]
+  );
+  const statusOptions = React.useMemo(
+    () => Array.from(new Set(data.map((item) => item.status).filter(Boolean))),
+    [data]
+  );
 
   const customGlobalFilter: FilterFn = (row, columnId, filterValue) => {
     const searchValue = filterValue.toLowerCase();
@@ -151,10 +187,7 @@ export function DataTable({ data, pocMap, urlMap }) {
     },
 
     {
-      accessorFn: (row) => ({
-        id: row.projeto_id?.id,
-        empresa: row.projeto_id?.empresa ?? "",
-      }),
+      accessorFn: (row) => row.projeto_id?.projeto ?? "",
       id: "projeto",
       header: ({ column }) => {
         return (
@@ -199,10 +232,7 @@ export function DataTable({ data, pocMap, urlMap }) {
     },
 
     {
-      accessorFn: (row) => ({
-        id: row.projeto_id?.id,
-        empresa: row.projeto_id?.empresa ?? "",
-      }),
+      accessorFn: (row) => row.projeto_id?.empresa ?? "",
       id: "empresa",
       header: ({ column }) => {
         return (
@@ -362,21 +392,133 @@ export function DataTable({ data, pocMap, urlMap }) {
     },
   });
 
+  const handleClearFilters = () => {
+    setGlobalFilter("");
+    setColumnFilters([]);
+    setFilterKey((k) => k + 1);
+  };
+
   return (
     <div className="w-full">
       <div className="flex justify-between items-center py-4">
         <NovoModal pocMap={pocMap} urlMap={urlMap} />
 
         <div className="flex gap-2 items-center">
-          <Input
-            placeholder="Pesquisar"
-            value={globalFilter}
-            onChange={(event) => setGlobalFilter(event.target.value)}
-            className="max-w-60"
-          />
+          {/* Filtro de Modelo */}
+          <Select
+            key={`model-${filterKey}`}
+            onValueChange={(value) =>
+              setColumnFilters((filters) => {
+                const withoutModel = filters.filter(
+                  (filter) => filter.id !== "model"
+                );
+                return value === "Todos"
+                  ? withoutModel
+                  : [...withoutModel, { id: "model", value }];
+              })
+            }
+            defaultValue="Todos"
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Modelo" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="Todos">Todos</SelectItem>
+              {modeloOptions.map((item) => (
+                <SelectItem key={item} value={item}>
+                  {item}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {/* Filtro de Tipo */}
+          <Select
+            key={`type-${filterKey}`}
+            onValueChange={(value) =>
+              setColumnFilters((filters) => {
+                const withoutType = filters.filter(
+                  (filter) => filter.id !== "type"
+                );
+                return value === "Todos"
+                  ? withoutType
+                  : [...withoutType, { id: "type", value }];
+              })
+            }
+            defaultValue="Todos"
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Tipo" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="Todos">Todos</SelectItem>
+              {tipoOptions.map((item) => (
+                <SelectItem key={item} value={item}>
+                  {item}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {/* Filtro de Projeto */}
+          <Select
+            key={`projeto-${filterKey}`}
+            onValueChange={(value) =>
+              setColumnFilters((filters) => {
+                const withoutProjeto = filters.filter(
+                  (filter) => filter.id !== "projeto"
+                );
+                return value === "Todos"
+                  ? withoutProjeto
+                  : [...withoutProjeto, { id: "projeto", value }];
+              })
+            }
+            defaultValue="Todos"
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Projeto" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="Todos">Todos</SelectItem>
+              {projetoOptions.map((item) => (
+                <SelectItem key={item} value={item}>
+                  {item}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {/* Filtro de Empresa */}
+          <Select
+            key={`empresa-${filterKey}`}
+            onValueChange={(value) =>
+              setColumnFilters((filters) => {
+                const withoutEmpresa = filters.filter(
+                  (filter) => filter.id !== "empresa"
+                );
+                return value === "Todos"
+                  ? withoutEmpresa
+                  : [...withoutEmpresa, { id: "empresa", value }];
+              })
+            }
+            defaultValue="Todos"
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Empresa" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="Todos">Todos</SelectItem>
+              {empresaOptions.map((item) => (
+                <SelectItem key={item} value={item}>
+                  {item}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
 
           {/* Filtro de Status */}
           <Select
+            key={`status-${filterKey}`}
             onValueChange={(value) =>
               setColumnFilters((filters) => {
                 const withoutStatus = filters.filter(
@@ -390,17 +532,28 @@ export function DataTable({ data, pocMap, urlMap }) {
             defaultValue="Todos"
           >
             <SelectTrigger>
-              <SelectValue placeholder="Filtrar por Status" />
+              <SelectValue placeholder="Status" />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="Todos">Todos</SelectItem>
-              <SelectItem value="Estoque">Estoque</SelectItem>
-              <SelectItem value="Em Uso">Em Uso</SelectItem>
-              <SelectItem value="RMA">RMA</SelectItem>
-              <SelectItem value="Vendido">Vendido</SelectItem>
-              <SelectItem value="Arquivado">Arquivado</SelectItem>
+              {statusOptions.map((item) => (
+                <SelectItem key={item} value={item}>
+                  {item}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
+
+          <Button variant="link" onClick={handleClearFilters}>
+            Limpar
+          </Button>
+
+          <Input
+            placeholder="Pesquisar"
+            value={globalFilter}
+            onChange={(event) => setGlobalFilter(event.target.value)}
+            className="max-w-60"
+          />
         </div>
       </div>
 

--- a/components/dashboard-cards.tsx
+++ b/components/dashboard-cards.tsx
@@ -2,7 +2,10 @@ import {
   getEquipamentosCadastrados,
   getEquipamentosStatus,
 } from "@/app/actions/actions_equipamentos";
-import { getProjetoCount } from "@/app/actions/actions_projetos";
+import {
+  getProjetoCount,
+  getProjetoStatusCount,
+} from "@/app/actions/actions_projetos";
 import {
   Card,
   CardContent,
@@ -13,6 +16,7 @@ import {
 async function DashboardCards() {
   const equipamentosCadastrados = await getEquipamentosCadastrados();
   const pocCount = await getProjetoCount();
+  const pocStatus = await getProjetoStatusCount();
   const equipamentosStatus = await getEquipamentosStatus();
 
   return (
@@ -51,6 +55,8 @@ async function DashboardCards() {
         </CardHeader>
         <CardContent>
           <Info info1={pocCount} info2={"POCs"} />
+          <Info info1={pocStatus.finalizadas} info2={"Finalizadas"} />
+          <Info info1={pocStatus.emAndamento} info2={"Em Andamento"} />
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- allow filtering equipamento table by model, type, project, company and status
- show counts of finalized and in-progress POCs on dashboard
- enable clearing all equipment filters and place search input at end of filter row

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Failed to fetch fonts and webpack errors)*

------
https://chatgpt.com/codex/tasks/task_e_689231c5e7c88320956052b391a9a56d