### PR TITLE
feat: identify equipment filters and add locação dashboard card

### DIFF
--- a/app/actions/actions_projetos.ts
+++ b/app/actions/actions_projetos.ts
@@ -106,32 +106,47 @@ export async function deleteProjeto(formData) {
   }
 }
 
-export async function getProjetoCount() {
+export async function getProjetoCount(projetoType?: string) {
   const supabase = createClient();
-  const { count, error } = await supabase
+  let query = supabase
     .from("projetos")
-    .select("*", { count: "exact" });
+    .select("*", { count: "exact", head: true });
+
+  if (projetoType) {
+    query = query.eq("projeto", projetoType);
+  }
+
+  const { count, error } = await query;
 
   if (error) {
     console.error("Erro ao buscar Projetos:", error);
-    return null;
+    return 0;
   }
 
-  return count;
+  return count ?? 0;
 }
 
-export async function getProjetoStatusCount() {
+export async function getProjetoStatusCount(projetoType?: string) {
   const supabase = createClient();
 
+  const emAndamentoQuery = supabase
+    .from("projetos")
+    .select("*", { count: "exact", head: true })
+    .eq("status", "Em Andamento");
+
+  const finalizadasQuery = supabase
+    .from("projetos")
+    .select("*", { count: "exact", head: true })
+    .eq("status", "Finalizada");
+
+  if (projetoType) {
+    emAndamentoQuery.eq("projeto", projetoType);
+    finalizadasQuery.eq("projeto", projetoType);
+  }
+
   const [emAndamento, finalizadas] = await Promise.all([
-    supabase
-      .from("projetos")
-      .select("*", { count: "exact", head: true })
-      .eq("status", "Em Andamento"),
-    supabase
-      .from("projetos")
-      .select("*", { count: "exact", head: true })
-      .eq("status", "Finalizada"),
+    emAndamentoQuery,
+    finalizadasQuery,
   ]);
 
   if (emAndamento.error) {

--- a/app/equipamentos/data-table.tsx
+++ b/app/equipamentos/data-table.tsx
@@ -403,7 +403,7 @@ export function DataTable({ data, pocMap, urlMap }) {
       <div className="flex justify-between items-center py-4">
         <NovoModal pocMap={pocMap} urlMap={urlMap} />
 
-        <div className="flex gap-2 items-center">
+        <div className="flex gap-1 items-center">
           <Button variant="link" onClick={handleClearFilters}>
             Limpar
           </Button>
@@ -425,7 +425,7 @@ export function DataTable({ data, pocMap, urlMap }) {
           >
             <SelectTrigger>
               <div className="flex items-center gap-1">
-                <span className="text-muted-foreground">Modelo:</span>
+                <span className="text-muted-foreground text-xs">Modelo:</span>
                 <SelectValue />
               </div>
             </SelectTrigger>
@@ -456,7 +456,7 @@ export function DataTable({ data, pocMap, urlMap }) {
           >
             <SelectTrigger>
               <div className="flex items-center gap-1">
-                <span className="text-muted-foreground">Tipo:</span>
+                <span className="text-muted-foreground text-xs">Tipo:</span>
                 <SelectValue />
               </div>
             </SelectTrigger>
@@ -487,7 +487,7 @@ export function DataTable({ data, pocMap, urlMap }) {
           >
             <SelectTrigger>
               <div className="flex items-center gap-1">
-                <span className="text-muted-foreground">Projeto:</span>
+                <span className="text-muted-foreground text-xs">Projeto:</span>
                 <SelectValue />
               </div>
             </SelectTrigger>
@@ -518,7 +518,7 @@ export function DataTable({ data, pocMap, urlMap }) {
           >
             <SelectTrigger>
               <div className="flex items-center gap-1">
-                <span className="text-muted-foreground">Empresa:</span>
+                <span className="text-muted-foreground text-xs">Empresa:</span>
                 <SelectValue />
               </div>
             </SelectTrigger>
@@ -550,7 +550,7 @@ export function DataTable({ data, pocMap, urlMap }) {
           >
             <SelectTrigger>
               <div className="flex items-center gap-1">
-                <span className="text-muted-foreground">Status:</span>
+                <span className="text-muted-foreground text-xs ">Status:</span>
                 <SelectValue />
               </div>
             </SelectTrigger>
@@ -568,7 +568,6 @@ export function DataTable({ data, pocMap, urlMap }) {
             placeholder="Pesquisar"
             value={globalFilter}
             onChange={(event) => setGlobalFilter(event.target.value)}
-            className="w-40"
           />
         </div>
       </div>

--- a/app/equipamentos/data-table.tsx
+++ b/app/equipamentos/data-table.tsx
@@ -424,7 +424,10 @@ export function DataTable({ data, pocMap, urlMap }) {
             defaultValue="Todos"
           >
             <SelectTrigger>
-              <SelectValue placeholder="Modelo" />
+              <div className="flex items-center gap-1">
+                <span className="text-muted-foreground">Modelo:</span>
+                <SelectValue />
+              </div>
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="Todos">Todos</SelectItem>
@@ -452,7 +455,10 @@ export function DataTable({ data, pocMap, urlMap }) {
             defaultValue="Todos"
           >
             <SelectTrigger>
-              <SelectValue placeholder="Tipo" />
+              <div className="flex items-center gap-1">
+                <span className="text-muted-foreground">Tipo:</span>
+                <SelectValue />
+              </div>
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="Todos">Todos</SelectItem>
@@ -480,7 +486,10 @@ export function DataTable({ data, pocMap, urlMap }) {
             defaultValue="Todos"
           >
             <SelectTrigger>
-              <SelectValue placeholder="Projeto" />
+              <div className="flex items-center gap-1">
+                <span className="text-muted-foreground">Projeto:</span>
+                <SelectValue />
+              </div>
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="Todos">Todos</SelectItem>
@@ -508,7 +517,10 @@ export function DataTable({ data, pocMap, urlMap }) {
             defaultValue="Todos"
           >
             <SelectTrigger>
-              <SelectValue placeholder="Empresa" />
+              <div className="flex items-center gap-1">
+                <span className="text-muted-foreground">Empresa:</span>
+                <SelectValue />
+              </div>
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="Todos">Todos</SelectItem>
@@ -537,7 +549,10 @@ export function DataTable({ data, pocMap, urlMap }) {
             defaultValue="Todos"
           >
             <SelectTrigger>
-              <SelectValue placeholder="Status" />
+              <div className="flex items-center gap-1">
+                <span className="text-muted-foreground">Status:</span>
+                <SelectValue />
+              </div>
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="Todos">Todos</SelectItem>

--- a/app/equipamentos/data-table.tsx
+++ b/app/equipamentos/data-table.tsx
@@ -398,15 +398,21 @@ export function DataTable({ data, pocMap, urlMap }) {
     setFilterKey((k) => k + 1);
   };
 
+  const hasActiveFilters = globalFilter !== "" || columnFilters.length > 0;
+  const isFilterActive = (id: string) =>
+    columnFilters.some((filter) => filter.id === id);
+
   return (
     <div className="w-full">
       <div className="flex justify-between items-center py-4">
         <NovoModal pocMap={pocMap} urlMap={urlMap} />
 
         <div className="flex gap-1 items-center">
-          <Button variant="link" onClick={handleClearFilters}>
-            Limpar
-          </Button>
+          {hasActiveFilters && (
+            <Button variant="link" onClick={handleClearFilters}>
+              Limpar
+            </Button>
+          )}
 
           {/* Filtro de Modelo */}
           <Select
@@ -425,7 +431,7 @@ export function DataTable({ data, pocMap, urlMap }) {
           >
             <SelectTrigger>
               <div className="flex items-center gap-1">
-                <span className="text-muted-foreground text-xs">Modelo:</span>
+                <span className="text-muted-foreground text-xs">Modelo</span>
                 <SelectValue />
               </div>
             </SelectTrigger>
@@ -456,7 +462,7 @@ export function DataTable({ data, pocMap, urlMap }) {
           >
             <SelectTrigger>
               <div className="flex items-center gap-1">
-                <span className="text-muted-foreground text-xs">Tipo:</span>
+                <span className="text-muted-foreground text-xs">Tipo</span>
                 <SelectValue />
               </div>
             </SelectTrigger>
@@ -487,7 +493,7 @@ export function DataTable({ data, pocMap, urlMap }) {
           >
             <SelectTrigger>
               <div className="flex items-center gap-1">
-                <span className="text-muted-foreground text-xs">Projeto:</span>
+                <span className="text-muted-foreground text-xs">Projeto</span>
                 <SelectValue />
               </div>
             </SelectTrigger>
@@ -518,7 +524,7 @@ export function DataTable({ data, pocMap, urlMap }) {
           >
             <SelectTrigger>
               <div className="flex items-center gap-1">
-                <span className="text-muted-foreground text-xs">Empresa:</span>
+                <span className="text-muted-foreground text-xs">Empresa</span>
                 <SelectValue />
               </div>
             </SelectTrigger>
@@ -550,7 +556,7 @@ export function DataTable({ data, pocMap, urlMap }) {
           >
             <SelectTrigger>
               <div className="flex items-center gap-1">
-                <span className="text-muted-foreground text-xs ">Status:</span>
+                <span className="text-muted-foreground text-xs ">Status</span>
                 <SelectValue />
               </div>
             </SelectTrigger>

--- a/app/equipamentos/page.tsx
+++ b/app/equipamentos/page.tsx
@@ -14,10 +14,10 @@ export default async function page() {
 
   return (
     <main className="px-2 pb-2 pt-4">
-      <DashboardCards />
-      <h1 className="border-b pb-2 text-xl font-bold tracking-tight flex items-center gap-1">
+      <h1 className="border-b mb-4 pb-2 text-xl font-bold tracking-tight flex items-center gap-1">
         <Wifi className="text-primary" /> Equipamentos
       </h1>
+      <DashboardCards />
       <DataTable urlMap={urlMap} data={equipamentos} pocMap={poc} />
     </main>
   );

--- a/components/dashboard-cards.tsx
+++ b/components/dashboard-cards.tsx
@@ -12,6 +12,7 @@ import {
   CardDescription,
   CardHeader,
 } from "@/components/ui/card";
+import Ping from "./ping";
 
 async function DashboardCards() {
   const equipamentosCadastrados = await getEquipamentosCadastrados();
@@ -53,20 +54,25 @@ async function DashboardCards() {
       </Card>
       <Card className="hover:shadow-lg transition-shadow duration-500 hover:shadow-violet-100">
         <CardHeader className="pb-2">
-          <CardDescription>Pocs cadastradas</CardDescription>
+          <CardDescription className="flex items-center gap-1">
+            <Ping color={"bg-blue-400"} /> Pocs cadastradas
+          </CardDescription>
         </CardHeader>
         <CardContent>
-          <Info info1={pocCount} info2={"POCs"} />
+          <Info info1={pocCount} info2={"POCs Totais"} />
           <Info info1={pocStatus.finalizadas} info2={"Finalizadas"} />
           <Info info1={pocStatus.emAndamento} info2={"Em Andamento"} />
         </CardContent>
       </Card>
       <Card className="hover:shadow-lg transition-shadow duration-500 hover:shadow-violet-100">
         <CardHeader className="pb-2">
-          <CardDescription>Locações cadastradas</CardDescription>
+          <CardDescription className="flex items-center gap-1">
+            <Ping color={"bg-orange-400"} />
+            Locações cadastradas
+          </CardDescription>
         </CardHeader>
         <CardContent>
-          <Info info1={locacaoCount} info2={"Locações"} />
+          <Info info1={locacaoCount} info2={"Locações Totais"} />
           <Info info1={locacaoStatus.finalizadas} info2={"Finalizadas"} />
           <Info info1={locacaoStatus.emAndamento} info2={"Em Andamento"} />
         </CardContent>

--- a/components/dashboard-cards.tsx
+++ b/components/dashboard-cards.tsx
@@ -15,12 +15,14 @@ import {
 
 async function DashboardCards() {
   const equipamentosCadastrados = await getEquipamentosCadastrados();
-  const pocCount = await getProjetoCount();
-  const pocStatus = await getProjetoStatusCount();
+  const pocCount = await getProjetoCount("poc");
+  const pocStatus = await getProjetoStatusCount("poc");
+  const locacaoCount = await getProjetoCount("locação");
+  const locacaoStatus = await getProjetoStatusCount("locação");
   const equipamentosStatus = await getEquipamentosStatus();
 
   return (
-    <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 mb-4">
+    <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2 mb-4">
       <Card className="hover:shadow-lg transition-shadow duration-500 hover:shadow-violet-100">
         <CardHeader className="pb-2">
           <CardDescription>Equipamentos cadastrados</CardDescription>
@@ -57,6 +59,16 @@ async function DashboardCards() {
           <Info info1={pocCount} info2={"POCs"} />
           <Info info1={pocStatus.finalizadas} info2={"Finalizadas"} />
           <Info info1={pocStatus.emAndamento} info2={"Em Andamento"} />
+        </CardContent>
+      </Card>
+      <Card className="hover:shadow-lg transition-shadow duration-500 hover:shadow-violet-100">
+        <CardHeader className="pb-2">
+          <CardDescription>Locações cadastradas</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Info info1={locacaoCount} info2={"Locações"} />
+          <Info info1={locacaoStatus.finalizadas} info2={"Finalizadas"} />
+          <Info info1={locacaoStatus.emAndamento} info2={"Em Andamento"} />
         </CardContent>
       </Card>
     </div>

--- a/components/ping.tsx
+++ b/components/ping.tsx
@@ -1,11 +1,11 @@
 function Ping({ color, animate }) {
   return (
-    <span className="relative flex h-3 w-3">
+    <span className="relative flex h-2.5 w-2.5">
       <span
         className={`${color} ${animate} absolute inline-flex h-full w-full rounded-full opacity-75`}
       ></span>
       <span
-        className={`${color} relative inline-flex rounded-full h-3 w-3`}
+        className={`${color} relative inline-flex rounded-full h-2.5 w-2.5`}
       ></span>
     </span>
   );


### PR DESCRIPTION
## Summary
- label each equipment filter so users can see which select controls model, type, project, company and status
- support project counts by category and show a new dashboard card for locações alongside POCs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch fonts / Build failed)*

------
https://chatgpt.com/codex/tasks/task_e_68923b0754588320be59faed8d644d93